### PR TITLE
Add tkinter GUI for chat client

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,11 @@ Server: Javascript(Node.js)
         - Node.jsのバージョンを変更
             - 最新バージョン: `nvm use node`
             - 安定バージョン: `nvm use --lts`
+
+## GUI Client
+Python版クライアントには簡易的なTkinter製GUIを用意しています。
+実行は次のコマンドです。
+```bash
+python gui_client.py
+```
+

--- a/client.py
+++ b/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import socket
 import threading
-from typing import Tuple
+from typing import Callable, Tuple
 
 
 TCP_SERVER_ADDRESS = "0.0.0.0"
@@ -35,21 +35,27 @@ def display_recv_message(data: bytes) -> None:
     print(f"{SPACE}message: {message.decode()}")
 
 
-def recv_and_display_message(sock: socket.socket) -> None:
-    """Receive UDP packets and display them until the socket is closed."""
+def recv_messages(sock: socket.socket, handler: Callable[[bytes], None]) -> None:
+    """Receive UDP packets and handle them using a callback."""
 
     while True:
         try:
             data, _ = sock.recvfrom(4096)
             if not data:
                 break
-            display_recv_message(data)
+            handler(data)
         except ConnectionResetError:
             print("Server disconnected")
             break
         except Exception as exc:  # pragma: no cover - best effort logging
             print(f"Error receiving message: {exc}")
             break
+
+
+def recv_and_display_message(sock: socket.socket) -> None:
+    """Wrapper to display received UDP packets."""
+
+    recv_messages(sock, display_recv_message)
 
 """
 # TCP for chatroom management
@@ -168,8 +174,17 @@ class ChatClient:
         operation_payload_size = int.from_bytes(response[3:32], byteorder="big")
         self.token = response[32 + roomname_size : 32 + roomname_size + operation_payload_size].decode()
 
-    def start_udp(self) -> None:
-        """Start UDP socket and receiving thread."""
+    def start_udp(
+        self, message_handler: Callable[[bytes], None] | None = None
+    ) -> None:
+        """Start UDP socket and receiving thread.
+
+        Parameters
+        ----------
+        message_handler:
+            Optional callback executed for every received UDP packet.
+            If omitted, messages are printed to stdout.
+        """
 
         try:
             udp_port = int(self.token)
@@ -178,7 +193,13 @@ class ChatClient:
 
         self.udp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.udp_sock.bind(("", udp_port))
-        thread = threading.Thread(target=recv_and_display_message, args=(self.udp_sock,), daemon=True)
+
+        handler = message_handler if message_handler else display_recv_message
+        thread = threading.Thread(
+            target=recv_messages,
+            args=(self.udp_sock, handler),
+            daemon=True,
+        )
         thread.start()
 
     def send_message(self, message: str) -> None:

--- a/gui_client.py
+++ b/gui_client.py
@@ -1,0 +1,84 @@
+import queue
+import tkinter as tk
+from tkinter import ttk, scrolledtext
+
+from client import ChatClient, process_udp_message
+
+
+class ChatUI:
+    """Simple Tkinter based GUI for :class:`ChatClient`."""
+
+    def __init__(self) -> None:
+        self.client = ChatClient()
+        self.root = tk.Tk()
+        self.root.title("Chat Client")
+        self.msg_queue: queue.Queue[bytes] = queue.Queue()
+        self._connected = False
+        self._build_widgets()
+
+    def _build_widgets(self) -> None:
+        connect = ttk.Frame(self.root, padding=10)
+        connect.pack(fill=tk.X)
+
+        ttk.Label(connect, text="Username:").pack(side=tk.LEFT)
+        self.username = ttk.Entry(connect, width=15)
+        self.username.pack(side=tk.LEFT, padx=5)
+
+        ttk.Label(connect, text="Room:").pack(side=tk.LEFT)
+        self.room = ttk.Entry(connect, width=15)
+        self.room.pack(side=tk.LEFT, padx=5)
+
+        ttk.Button(connect, text="Connect", command=self.connect).pack(side=tk.LEFT)
+
+        self.text = scrolledtext.ScrolledText(self.root, state="disabled", width=60, height=20)
+        self.text.pack(padx=10, pady=10, fill=tk.BOTH, expand=True)
+
+        entry = ttk.Frame(self.root, padding=10)
+        entry.pack(fill=tk.X)
+
+        self.message = ttk.Entry(entry)
+        self.message.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        ttk.Button(entry, text="Send", command=self.send).pack(side=tk.LEFT, padx=5)
+
+    def connect(self) -> None:
+        try:
+            self.client.handshake(self.username.get(), self.room.get())
+            self.client.start_udp(lambda data: self.msg_queue.put(data))
+            self._connected = True
+            self.root.after(100, self._process_messages)
+        except Exception as exc:  # pragma: no cover - best effort logging
+            self._append(f"Connection error: {exc}\n")
+
+    def _process_messages(self) -> None:
+        while not self.msg_queue.empty():
+            data = self.msg_queue.get_nowait()
+            _, _, msg = process_udp_message(data)
+            self._append(msg.decode() + "\n")
+        if self._connected:
+            self.root.after(100, self._process_messages)
+
+    def send(self) -> None:
+        if not self._connected:
+            self._append("Not connected.\n")
+            return
+        msg = self.message.get()
+        if not msg:
+            return
+        try:
+            self.client.send_message(msg)
+            self.message.delete(0, tk.END)
+        except Exception as exc:  # pragma: no cover - best effort logging
+            self._append(f"Send error: {exc}\n")
+
+    def _append(self, text: str) -> None:
+        self.text.configure(state="normal")
+        self.text.insert(tk.END, text)
+        self.text.see(tk.END)
+        self.text.configure(state="disabled")
+
+    def run(self) -> None:
+        self.root.mainloop()
+
+
+if __name__ == "__main__":
+    ChatUI().run()


### PR DESCRIPTION
## Summary
- create a GUI front-end for the client using tkinter
- allow `ChatClient.start_udp()` to register a custom callback for incoming messages
- document how to launch the GUI

## Testing
- `python -m py_compile client.py gui_client.py server.py`

------
https://chatgpt.com/codex/tasks/task_b_6846cd2d38e883269c66d3d5cc757b76